### PR TITLE
Enable multi-core by default

### DIFF
--- a/raphael-cli/src/commands/solve.rs
+++ b/raphael-cli/src/commands/solve.rs
@@ -134,6 +134,10 @@ pub enum ConsumableArg {
     HQ(u32),
 }
 
+fn default_thread_count() -> usize {
+    std::thread::available_parallelism().map_or(4, |n| n.get())
+}
+
 fn map_and_clamp_hq_ingredients(recipe: &raphael_data::Recipe, hq_ingredients: [u8; 6]) -> [u8; 6] {
     let ingredients: Vec<(raphael_data::Item, u32)> = recipe
         .ingredients
@@ -168,6 +172,11 @@ pub fn execute(args: &SolveArgs) {
     if let Some(threads) = args.threads {
         rayon::ThreadPoolBuilder::new()
             .num_threads(threads)
+            .build_global()
+            .unwrap();
+    } else {
+        rayon::ThreadPoolBuilder::new()
+            .num_threads(default_thread_count())
             .build_global()
             .unwrap();
     }

--- a/raphael-solver/src/quality_upper_bound_solver/solver.rs
+++ b/raphael-solver/src/quality_upper_bound_solver/solver.rs
@@ -237,21 +237,23 @@ impl QualityUbSolver {
             reduced_state.effects,
             reduced_state.compressed_unreliable_quality,
         );
-        if let Some(&required_cp) = self.maximal_templates.get(&template_data)
-            && reduced_state.cp >= required_cp
-        {
-            let reduced_state = ReducedState {
-                cp: required_cp,
-                ..reduced_state
-            };
-            #[cfg(test)]
-            assert!(self.solved_states.contains_key(&reduced_state));
-            if let Some(pareto_front) = self.solved_states.get(&reduced_state)
-                && let Some(value) = pareto_front.last()
-                && value.first >= required_progress
-                && value.second + state.quality >= self.settings.max_quality()
-            {
-                return Ok(self.settings.max_quality());
+        if let Some(&required_cp) = self.maximal_templates.get(&template_data) {
+            if reduced_state.cp >= required_cp {
+                let reduced_state = ReducedState {
+                    cp: required_cp,
+                    ..reduced_state
+                };
+                #[cfg(test)]
+                assert!(self.solved_states.contains_key(&reduced_state));
+                if let Some(pareto_front) = self.solved_states.get(&reduced_state) {
+                    if let Some(value) = pareto_front.last() {
+                        if value.first >= required_progress
+                            && value.second + state.quality >= self.settings.max_quality()
+                        {
+                            return Ok(self.settings.max_quality());
+                        }
+                    }
+                }
             }
         }
 

--- a/raphael-solver/src/step_lower_bound_solver/solver.rs
+++ b/raphael-solver/src/step_lower_bound_solver/solver.rs
@@ -152,33 +152,36 @@ impl StepLbSolver {
             if let Ok(new_state) = use_action_combo(&self.settings, state.to_state(), action) {
                 let progress = new_state.progress;
                 let quality = new_state.quality;
-                if let Ok(new_step_budget) = NonZeroU8::try_from(new_step_budget)
-                    && new_state.durability > 0
-                {
-                    let new_state = ReducedState::from_state(new_state, new_step_budget);
-                    if let Some(pareto_front) = self.solved_states.get(&new_state) {
-                        pareto_front_builder.push_slice(pareto_front);
-                    } else if !new_state.effects.allow_quality_actions() {
-                        // States that disallow quality actions get filtered out early because they only need to reach max_progress, whereas normal states need to reach both max_progress and max_quality to be fitered out.
-                        // So if the new state does not allow quality actions and cannot be found in the already solved state, we assume that it has reached max_progress using a lower step budget.
-                        // IMPORTANT: A missing child state could also mean that there is something wrong with the precompute template generation, but the consistency fuzz check should hopefully catch this case.
+                match NonZeroU8::try_from(new_step_budget) {
+                    Ok(new_step_budget) if new_state.durability > 0 => {
+                        let new_state = ReducedState::from_state(new_state, new_step_budget);
+                        if let Some(pareto_front) = self.solved_states.get(&new_state) {
+                            pareto_front_builder.push_slice(pareto_front);
+                        } else if !new_state.effects.allow_quality_actions() {
+                            // States that disallow quality actions get filtered out early because they only need to reach max_progress, whereas normal states need to reach both max_progress and max_quality to be fitered out.
+                            // So if the new state does not allow quality actions and cannot be found in the already solved state, we assume that it has reached max_progress using a lower step budget.
+                            // IMPORTANT: A missing child state could also mean that there is something wrong with the precompute template generation, but the consistency fuzz check should hopefully catch this case.
+                            pareto_front_builder
+                                .push_slice(&[ParetoValue::new(self.settings.max_progress(), 0)]);
+                        } else {
+                            unreachable!("Parent: {state:?}\nChild: {new_state:?}\nAction: {action:?}");
+                        }
                         pareto_front_builder
-                            .push_slice(&[ParetoValue::new(self.settings.max_progress(), 0)]);
-                    } else {
-                        unreachable!("Parent: {state:?}\nChild: {new_state:?}\nAction: {action:?}");
+                            .peek_mut()
+                            .unwrap()
+                            .iter_mut()
+                            .for_each(|value| {
+                                value.first += progress;
+                                value.second += quality;
+                            });
+                        pareto_front_builder.merge();
                     }
-                    pareto_front_builder
-                        .peek_mut()
-                        .unwrap()
-                        .iter_mut()
-                        .for_each(|value| {
-                            value.first += progress;
-                            value.second += quality;
-                        });
-                    pareto_front_builder.merge();
-                } else if progress != 0 {
-                    pareto_front_builder.push_slice(&[ParetoValue::new(progress, quality)]);
-                    pareto_front_builder.merge();
+                    _ => {
+                        if progress != 0 {
+                            pareto_front_builder.push_slice(&[ParetoValue::new(progress, quality)]);
+                            pareto_front_builder.merge();
+                        }
+                    }
                 }
             }
         }

--- a/raphael-solver/src/test_utils.rs
+++ b/raphael-solver/src/test_utils.rs
@@ -25,10 +25,10 @@ pub fn generate_random_states(
         let state = generated_states[rng.random_range(0..generated_states.len())];
         for _ in 0..5 {
             let action = FULL_SEARCH_ACTIONS[rng.random_range(0..FULL_SEARCH_ACTIONS.len())];
-            if let Ok(new_state) = use_action_combo(&settings, state, action)
-                && !new_state.is_final(&settings.simulator_settings)
-            {
-                generated_states.push(new_state);
+            if let Ok(new_state) = use_action_combo(&settings, state, action) {
+                if !new_state.is_final(&settings.simulator_settings) {
+                    generated_states.push(new_state);
+                }
             }
         }
     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -1102,18 +1102,21 @@ impl MacroSolverApp {
             );
         });
 
-        if self.saved_rotations_config.load_from_saved_rotations
-            && let Some(actions) = self.saved_rotations_data.find_solved_rotation(
+        if self.saved_rotations_config.load_from_saved_rotations {
+            if let Some(actions) = self.saved_rotations_data.find_solved_rotation(
                 &game_settings,
                 initial_quality,
                 &self.solver_config,
-            )
+            ) {
+                let mut solver_events = self.solver_events.lock().unwrap();
+                solver_events.push_back(SolverEvent::Actions(actions));
+                solver_events.push_back(SolverEvent::LoadedFromHistory());
+                solver_events.push_back(SolverEvent::Finished(None));
+                return;
+            }
+        }
+
         {
-            let mut solver_events = self.solver_events.lock().unwrap();
-            solver_events.push_back(SolverEvent::Actions(actions));
-            solver_events.push_back(SolverEvent::LoadedFromHistory());
-            solver_events.push_back(SolverEvent::Finished(None));
-        } else {
             let target_quality = self
                 .solver_config
                 .quality_target

--- a/src/thread_pool.rs
+++ b/src/thread_pool.rs
@@ -57,10 +57,8 @@ fn initialize(num_threads: Option<NonZeroUsize>) {
 
 #[cfg(not(target_arch = "wasm32"))]
 pub fn default_thread_count() -> NonZeroUsize {
-    std::thread::available_parallelism().map_or(NonZeroUsize::new(4).unwrap(), |detected| {
-        let num_threads = std::cmp::max(2, detected.get() / 2);
-        NonZeroUsize::new(num_threads).unwrap()
-    })
+    std::thread::available_parallelism()
+        .unwrap_or_else(|_| NonZeroUsize::new(4).unwrap())
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -68,7 +66,7 @@ pub fn default_thread_count() -> NonZeroUsize {
     let window = web_sys::window().unwrap();
     let detected = window.navigator().hardware_concurrency() as usize;
     // See https://github.com/KonaeAkira/raphael-rs/issues/169
-    NonZeroUsize::new((detected / 2).clamp(2, 8)).unwrap()
+    NonZeroUsize::new(detected.clamp(2, 8)).unwrap()
 }
 
 #[cfg(not(target_arch = "wasm32"))]

--- a/src/widgets/saved_rotations.rs
+++ b/src/widgets/saved_rotations.rs
@@ -236,13 +236,14 @@ impl SavedRotationsData {
         let find_and_map_rotation = |rotation: &Rotation| {
             if let (Some(saved_solver_version), Some(saved_solve_info)) =
                 (rotation.solver.split(' ').nth(1), &rotation.solve_info)
-                && saved_solver_version == format!("v{}", env!("CARGO_PKG_VERSION"))
-                && *saved_solve_info == solve_info
             {
-                Some(rotation.actions.clone())
-            } else {
-                None
+                if saved_solver_version == format!("v{}", env!("CARGO_PKG_VERSION"))
+                    && *saved_solve_info == solve_info
+                {
+                    return Some(rotation.actions.clone());
+                }
             }
+            None
         };
         let history_search_result = self.solve_history.iter().find_map(find_and_map_rotation);
         if history_search_result.is_some() {


### PR DESCRIPTION
## Summary
- default to using all available CPU cores when building the thread pool
- ensure CLI also initializes a Rayon thread pool with either the provided `--threads` value or the detected core count
- fix unstable `if-let` chains in solver and UI code to compile on stable Rust

## Testing
- `cargo test -p raphael-cli -- --test-threads=1`
- `cargo test --workspace` *(partial run; heavy test suite)*

------
https://chatgpt.com/codex/tasks/task_e_685af38ebb6c8332a8027e57fec7bc55