### PR TITLE
Parallel search improvements

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,0 +1,22 @@
+name: Build Release
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use nightly toolchain
+        run: rustup update nightly && rustup default nightly
+      - name: Build release
+        run: cargo build --release
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: raphael_release
+          path: target/release/raphael-xiv

--- a/raphael-solver/src/macro_solver/solver.rs
+++ b/raphael-solver/src/macro_solver/solver.rs
@@ -9,6 +9,8 @@ use crate::utils::AtomicFlag;
 use crate::utils::ScopedTimer;
 use crate::{FinishSolver, QualityUbSolver, SolverException, SolverSettings, StepLbSolver};
 
+use rayon::prelude::*;
+
 use std::vec::Vec;
 
 #[derive(Clone)]
@@ -111,81 +113,86 @@ impl<'a> MacroSolver<'a> {
                 (self.progress_callback)(popped);
             }
 
-            for action in FULL_SEARCH_ACTIONS {
-                if let Ok(state) = use_action_combo(&self.settings, state, action) {
-                    if !state.is_final(&self.settings.simulator_settings) {
-                        if !self.finish_solver.can_finish(&state) {
-                            // skip this state if it is impossible to max out Progress
-                            continue;
-                        }
+            let children: Vec<(ActionCombo, SimulationState)> = FULL_SEARCH_ACTIONS
+                .par_iter()
+                .filter_map(|&action| {
+                    use_action_combo(&self.settings, state, action)
+                        .ok()
+                        .map(|child| (action, child))
+                })
+                .collect();
 
-                        search_queue.update_min_score(SearchScore {
-                            quality_upper_bound: std::cmp::min(
-                                state.quality,
-                                self.settings.max_quality(),
-                            ),
-                            ..SearchScore::MIN
-                        });
+            for (action, state) in children {
+                if !state.is_final(&self.settings.simulator_settings) {
+                    if !self.finish_solver.can_finish(&state) {
+                        // skip this state if it is impossible to max out Progress
+                        continue;
+                    }
 
-                        let quality_upper_bound = if state.quality >= self.settings.max_quality() {
-                            self.settings.max_quality()
-                        } else {
-                            std::cmp::min(
-                                score.quality_upper_bound,
-                                self.quality_ub_solver.quality_upper_bound(state)?,
-                            )
-                        };
+                    search_queue.update_min_score(SearchScore {
+                        quality_upper_bound: std::cmp::min(
+                            state.quality,
+                            self.settings.max_quality(),
+                        ),
+                        ..SearchScore::MIN
+                    });
 
-                        let step_lb_hint = score
-                            .steps_lower_bound
-                            .saturating_sub(score.current_steps + action.steps());
-                        let steps_lower_bound =
-                            match quality_upper_bound >= self.settings.max_quality() {
-                                true => self
-                                    .step_lb_solver
-                                    .step_lower_bound(state, step_lb_hint)?
-                                    .saturating_add(score.current_steps + action.steps()),
-                                false => score.current_steps + action.steps(),
-                            };
+                    let quality_upper_bound = if state.quality >= self.settings.max_quality() {
+                        self.settings.max_quality()
+                    } else {
+                        std::cmp::min(
+                            score.quality_upper_bound,
+                            self.quality_ub_solver.quality_upper_bound(state)?,
+                        )
+                    };
 
-                        search_queue.push(
-                            state,
-                            SearchScore {
-                                quality_upper_bound,
-                                steps_lower_bound,
-                                duration_lower_bound: score.current_duration
-                                    + action.duration()
-                                    + 3,
-                                current_steps: score.current_steps + action.steps(),
-                                current_duration: score.current_duration + action.duration(),
-                            },
-                            action,
-                            backtrack_id,
-                        );
-                    } else if state.progress >= self.settings.max_progress() {
-                        let solution_score = SearchScore {
-                            quality_upper_bound: std::cmp::min(
-                                state.quality,
-                                self.settings.max_quality(),
-                            ),
-                            steps_lower_bound: score.current_steps + action.steps(),
-                            duration_lower_bound: score.current_duration + action.duration(),
+                    let step_lb_hint = score
+                        .steps_lower_bound
+                        .saturating_sub(score.current_steps + action.steps());
+                    let steps_lower_bound = match quality_upper_bound >= self.settings.max_quality()
+                    {
+                        true => self
+                            .step_lb_solver
+                            .step_lower_bound(state, step_lb_hint)?
+                            .saturating_add(score.current_steps + action.steps()),
+                        false => score.current_steps + action.steps(),
+                    };
+
+                    search_queue.push(
+                        state,
+                        SearchScore {
+                            quality_upper_bound,
+                            steps_lower_bound,
+                            duration_lower_bound: score.current_duration + action.duration() + 3,
                             current_steps: score.current_steps + action.steps(),
                             current_duration: score.current_duration + action.duration(),
-                        };
-                        search_queue.update_min_score(solution_score);
-                        if solution.is_none()
-                            || solution.as_ref().unwrap().score < (solution_score, state.quality)
-                        {
-                            solution = Some(Solution {
-                                score: (solution_score, state.quality),
-                                solver_actions: search_queue
-                                    .backtrack(backtrack_id)
-                                    .chain(std::iter::once(action))
-                                    .collect(),
-                            });
-                            (self.solution_callback)(&solution.as_ref().unwrap().actions());
-                        }
+                        },
+                        action,
+                        backtrack_id,
+                    );
+                } else if state.progress >= self.settings.max_progress() {
+                    let solution_score = SearchScore {
+                        quality_upper_bound: std::cmp::min(
+                            state.quality,
+                            self.settings.max_quality(),
+                        ),
+                        steps_lower_bound: score.current_steps + action.steps(),
+                        duration_lower_bound: score.current_duration + action.duration(),
+                        current_steps: score.current_steps + action.steps(),
+                        current_duration: score.current_duration + action.duration(),
+                    };
+                    search_queue.update_min_score(solution_score);
+                    if solution.is_none()
+                        || solution.as_ref().unwrap().score < (solution_score, state.quality)
+                    {
+                        solution = Some(Solution {
+                            score: (solution_score, state.quality),
+                            solver_actions: search_queue
+                                .backtrack(backtrack_id)
+                                .chain(std::iter::once(action))
+                                .collect(),
+                        });
+                        (self.solution_callback)(&solution.as_ref().unwrap().actions());
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- use Rayon in `MacroSolver` for exploring actions
- add a build-release workflow

## Testing
- `cargo +nightly test --workspace` *(build attempted but cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_685af45e44d08332a239af19445f20fa